### PR TITLE
Add links to index trail table

### DIFF
--- a/About.Rmd
+++ b/About.Rmd
@@ -30,4 +30,6 @@ The name, *52 Weekly Saunter Challenge*, is derived from a quote ascribed to [Jo
 - John Muir 
 >
 
-I am certified as a Sierra Club Outings leader, and my main focus with the Sierra Club is getting veterans into nature at Camp Elk Tannery in rural Pennsylvania. I use [Alltrails](https://www.alltrails.com/members/ebcrenshaw3) and/or [FitBit](https://www.fitbit.com/us/home) to track my hikes. 
+*Outdoors Certifications:* Certified as a Sierra Club Outings leader with a primary focus on getting veterans into nature at Camp Elk Tannery in rural Pennsylvania. 
+
+*Hike Tracking Software:* [Alltrails](https://www.alltrails.com/members/ebcrenshaw3) and/or [FitBit](https://www.fitbit.com/us/home) are used to track hikes, but only Alltrails tracks are publically available. 

--- a/docs/About.html
+++ b/docs/About.html
@@ -299,7 +299,8 @@ $(document).ready(function () {
 <blockquote>
 <p>Hiking - “I don’t like either the word or the thing. People ought to saunter in the mountains - not hike! Do you know the origin of that word ‘saunter?’ It’s a beautiful word. Away back in the Middle Ages people used to go on pilgrimages to the Holy Land, and when people in the villages through which they passed asked where they were going, they would reply, ‘A la sainte terre,’ ‘To the Holy Land.’ And so they became known as sainte-terre-ers or saunterers. Now these mountains are our Holy Land, and we ought to saunter through them reverently, not ‘hike’ through them.” - John Muir</p>
 </blockquote>
-<p>I am certified as a Sierra Club Outings leader, and my main focus with the Sierra Club is getting veterans into nature at Camp Elk Tannery in rural Pennsylvania. I use <a href="https://www.alltrails.com/members/ebcrenshaw3">Alltrails</a> and/or <a href="https://www.fitbit.com/us/home">FitBit</a> to track my hikes.</p>
+<p><em>Outdoors Certifications:</em> Certified as a Sierra Club Outings leader with a primary focus on getting veterans into nature at Camp Elk Tannery in rural Pennsylvania.</p>
+<p><em>Hike Tracking Software:</em> <a href="https://www.alltrails.com/members/ebcrenshaw3">Alltrails</a> and/or <a href="https://www.fitbit.com/us/home">FitBit</a> are used to track hikes, but only Alltrails tracks are publically available.</p>
 
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -315,7 +315,7 @@ $(document).ready(function () {
 <tr class="odd">
 <td>1-Jan-20</td>
 <td>Marsh Creek State Park</td>
-<td>White Trail</td>
+<td><a href="https://www.alltrails.com/explore/recording/marsh-creek-trail--382">White Trail</a></td>
 </tr>
 <tr class="even">
 <td>5-Jan-20</td>
@@ -330,7 +330,7 @@ $(document).ready(function () {
 <tr class="even">
 <td>12-Jan-20</td>
 <td>Delaware Water Gap</td>
-<td>Mt Minsi via AT</td>
+<td><a href="https://www.alltrails.com/explore/recording/mount-minsi-via-appalachian-trail--1464">Mt Minsi via AT</a></td>
 </tr>
 <tr class="odd">
 <td>15-Jan-20</td>
@@ -340,12 +340,12 @@ $(document).ready(function () {
 <tr class="even">
 <td>19-Jan-20</td>
 <td>Hopewell FurnaceNHS/French Creek State Park</td>
-<td>Lenape Trail to Mill Creek Trail Loop</td>
+<td><a href="https://www.alltrails.com/explore/recording/lenape-trail-to-mill-creek-trail-loop--69">Lenape Trail to Mill Creek Trail Loop</a></td>
 </tr>
 <tr class="odd">
 <td>26-Jan-20</td>
 <td>Hickory Run SP</td>
-<td>Shades of Death</td>
+<td><a href="https://www.alltrails.com/explore/recording/shades-of-death-trail--588">Shades of Death</a></td>
 </tr>
 </tbody>
 </table>

--- a/index.Rmd
+++ b/index.Rmd
@@ -17,13 +17,13 @@ Inspired by the [52 Hike Challenge](https://www.52hikechallenge.com/), I am taki
 
 | Date    | Park                  | Trail  |
 |---------|-----------------------|-------------|
-|1-Jan-20| Marsh Creek State Park	|White Trail|
+|1-Jan-20| Marsh Creek State Park	|[White Trail](https://www.alltrails.com/explore/recording/marsh-creek-trail--382)|
 |5-Jan-20| Wissahickon	          |Carpenter's Woods Trails|
 |11-Jan-20|Wissahickon	          |Towanda>White>Lavender|
-|12-Jan-20|Delaware Water Gap	    |Mt Minsi via AT|
+|12-Jan-20|Delaware Water Gap	    |[Mt Minsi via AT](https://www.alltrails.com/explore/recording/mount-minsi-via-appalachian-trail--1464)|
 |15-Jan-20|Wissahickon	          |Kitchens Lane>White>Orange|
-|19-Jan-20|	Hopewell FurnaceNHS/French Creek State Park	|Lenape Trail to Mill Creek Trail Loop|
-|26-Jan-20|	Hickory Run SP	      |Shades of Death|
+|19-Jan-20|	Hopewell FurnaceNHS/French Creek State Park	|[Lenape Trail to Mill Creek Trail Loop](https://www.alltrails.com/explore/recording/lenape-trail-to-mill-creek-trail-loop--69)|
+|26-Jan-20|	Hickory Run SP	      |[Shades of Death](https://www.alltrails.com/explore/recording/shades-of-death-trail--588)|
 
 ```{r}
 


### PR DESCRIPTION
Alltrail.com links are publicly available, and were added to the table on the Home Page.